### PR TITLE
Fix unit test name

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -31,7 +31,7 @@ require_once(__DIR__.'/../locallib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_securityquestions_locallib_testcase extends advanced_testcase {
+class tool_securityquestions_locallib_test extends advanced_testcase {
 
     /**
      * Insert question test


### PR DESCRIPTION
Small name change, shouldn't have an impact on Moodle but is a partial compatibility fix for T19 unit tests (not addressing other issues are they aren't universal)