### PR TITLE
Issue #122: Updated class name for locallib_test

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -21,6 +21,8 @@
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+namespace tool_securityquestions;
+
 defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__.'/../locallib.php');
 
@@ -31,7 +33,7 @@ require_once(__DIR__.'/../locallib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class locallib_test extends advanced_testcase {
+class locallib_test extends \advanced_testcase {
 
     /**
      * Insert question test

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -31,7 +31,7 @@ require_once(__DIR__.'/../locallib.php');
  * @copyright  2019 Peter Burnett <peterburnett@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class tool_securityquestions_locallib_testcase extends advanced_testcase {
+class locallib_test extends advanced_testcase {
 
     /**
      * Insert question test


### PR DESCRIPTION
Closes issue #122.

Updated the class name for `locallib_test.php` to match the file name. This allows the tests to be run properly.

## Environment
```
- Moodle 5.1.3+ (Build: 20260220)
- PHP: 8.4.22
- DB: MySQL 8.4
- Branch: MOODLE_401_STABLE
```

## Testing instructions:
- `tool_securityquestions` test suite: `vendor/bin/phpunit --testsuite tool_securityquestions_testsuite`
- Running the unit tests for `tool_securityquestions` will produce the following output (on the above environment):
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

There was 1 PHPUnit test runner warning:

1) Class locallib_test cannot be found in /var/www/upstream-mdl/public/admin/tool/securityquestions/tests/locallib_test.php

No tests executed!
```
### Expected Output from PHPUnit Tests
- Pulling this branch `MOODLE_401_STABLE-issue122` and re-running the testsuite:
```
Moodle 5.1.3+ (Build: 20260220)
Php: 8.4.22, mysqli: 8.4.9, OS: Linux 6.17.0-1025-oem x86_64
PHPUnit 11.5.12 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.22
Configuration: /var/www/upstream-mdl/phpunit.xml

................................                                  32 / 32 (100%)

Time: 00:05.930, Memory: 72.50 MB

OK, but there were issues!
Tests: 32, Assertions: 151, PHPUnit Deprecations: 2.
```